### PR TITLE
[RFC] Before trying to lower() an AbstractArray, replace undef values with a defined value of the same type - fixes #3

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -56,7 +56,32 @@ tags[:unionall] = d -> UnionAll(d[:var], d[:body])
 lower(x::Vector{Any}) = copy(x)
 lower(x::Vector{UInt8}) = x
 
+function fix_undefs(x::AbstractArray{<:AbstractString})
+  result = similar(x)
+  for i = 1:length(x)
+    if isassigned(x, i)
+      result[i] = x[i]
+    else
+      result[i] = "ignored"
+    end
+  end
+  return result
+end
+
+function fix_undefs(x::AbstractArray{Symbol})
+  result = similar(x)
+  for i = 1:length(x)
+    if isassigned(x, i)
+      result[i] = x[i]
+    else
+      result[i] = :ignored
+    end
+  end
+  return result
+end
+
 function lower(x::Array)
+  x = fix_undefs(x)
   ndims(x) == 1 && !isbits(eltype(x)) && return Any[x...]
   BSONDict(:tag => "array", :type => eltype(x), :size => Any[size(x)...],
            :data => isbits(eltype(x)) ? reinterpret(UInt8, reshape(x, :)) : Any[x...])


### PR DESCRIPTION
This is a really hacky way to solve #3. The basic idea is this: before trying to lower() an AbstractArray, we go through the array and replace all the #undef values with a value of the appropriate type. (Specifically, we replace the #undef values with the first defined value in the array.)

For example, if we have an array that looks like this:
```julia
5-element Array{String,1}:
 #undef
    "b"
 #undef
    "d"
    "e"
```
Then, before we try to lower() it, we change the #undef values so the array looks like this:
```julia
5-element Array{String,1}:
    "b"
    "b"
    "b"
    "d"
    "e"
```

It seems like those values are ignored, so it doesn't matter what we set them to, as long as we set them to values of the appropriate type.