### PR TITLE
Handle undefined values in arrays

### DIFF
--- a/src/BSON.jl
+++ b/src/BSON.jl
@@ -22,6 +22,7 @@ end
 
 function applychildren!(f, x::BSONArray)
   for i = 1:length(x)
+    isassigned(x, i) || continue
     x[i] = f(x[i])
   end
   return x

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -56,10 +56,18 @@ tags[:unionall] = d -> UnionAll(d[:var], d[:body])
 lower(x::Vector{Any}) = copy(x)
 lower(x::Vector{UInt8}) = x
 
+function collect_any(xs)
+  ys = Vector{Any}(length(xs))
+  for i = 1:length(xs)
+    isassigned(xs, i) && (ys[i] = xs[i])
+  end
+  return ys
+end
+
 function lower(x::Array)
-  ndims(x) == 1 && !isbits(eltype(x)) && return Any[x...]
+  ndims(x) == 1 && !isbits(eltype(x)) && return collect_any(x)
   BSONDict(:tag => "array", :type => eltype(x), :size => Any[size(x)...],
-           :data => isbits(eltype(x)) ? reinterpret(UInt8, reshape(x, :)) : Any[x...])
+           :data => isbits(eltype(x)) ? reinterpret(UInt8, reshape(x, :)) : collect_any(x))
 end
 
 tags[:array] = d ->

--- a/src/write.jl
+++ b/src/write.jl
@@ -35,7 +35,8 @@ end
 
 bson_primitive(io::IO, doc::BSONDict) = bson_doc(io, doc)
 bson_primitive(io::IO, x::BSONArray) =
-  bson_doc(io, [Base.string(i-1) => v for (i, v) in enumerate(x)])
+  bson_doc(io, [Base.string(i-1) => isassigned(x, i) ? x[i] : nothing
+                for i = 1:length(x)])
 
 # Lowering
 


### PR DESCRIPTION
For now this just writes `undefined`s as `nothing` (which works because we don't preserve non-isbits-eltypes anyway). Probably better to use a different sentinel and preserve `undefined`-ness through a roundtrip.