### PR TITLE
Quickfix for Undefined Symbols

### DIFF
--- a/src/BSON.jl
+++ b/src/BSON.jl
@@ -1,5 +1,6 @@
 module BSON
 
+using Core: SimpleVector, TypeName
 export bson
 
 const BSONDict = Dict{Symbol,Any}


### PR DESCRIPTION
Fixes minor undefined errors, i.e.
```
ERROR: LoadError: LoadError: UndefVarError: SimpleVector not defined 
```