### PR TITLE
Handle arrays of Nothing

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -70,8 +70,8 @@ end
 
 tags[:array] = d ->
   isbitstype(d[:type]) ?
-    d[:type] == Nothing ?
-      fill(nothing, d[:size]...) :
+    sizeof(d[:type]) == 0 ?
+      fill(d[:type](), d[:size]...) :
       reshape(reinterpret_(d[:type], d[:data]), d[:size]...) :
     Array{d[:type]}(reshape(d[:data], d[:size]...))
 

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -70,7 +70,9 @@ end
 
 tags[:array] = d ->
   isbitstype(d[:type]) ?
-    reshape(reinterpret_(d[:type], d[:data]), d[:size]...) :
+    d[:type] == Nothing ?
+      fill(nothing, d[:size]...) :
+      reshape(reinterpret_(d[:type], d[:data]), d[:size]...) :
     Array{d[:type]}(reshape(d[:data], d[:size]...))
 
 # Structs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,9 @@ end
   @test roundtrip_equal(rand(2,3))
   @test roundtrip_equal(Array{Real}(rand(2,3)))
   @test roundtrip_equal(1+2im)
+  @test roundtrip_equal(Nothing[])
+  @test roundtrip_equal(fill(nothing, (3,2)))
+  @test roundtrip_equal(Set([1,2,3]))
   @test roundtrip_equal(Dict("a"=>1))
   @test roundtrip_equal(T(()))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,8 @@ struct T{A}
   x::A
 end
 
+struct S end
+
 @testset "BSON" begin
 
 @testset "Primitive Types" begin
@@ -34,7 +36,9 @@ end
   @test roundtrip_equal(Array{Real}(rand(2,3)))
   @test roundtrip_equal(1+2im)
   @test roundtrip_equal(Nothing[])
+  @test roundtrip_equal(S[])
   @test roundtrip_equal(fill(nothing, (3,2)))
+  @test roundtrip_equal(fill(S(), (1,3)))
   @test roundtrip_equal(Set([1,2,3]))
   @test roundtrip_equal(Dict("a"=>1))
   @test roundtrip_equal(T(()))


### PR DESCRIPTION
Implements the small change described in my corresponding issue (#22) to fix the loading of arrays of Nothing, and adds some corresponding tests. Saving/loading of sets is then fixed as well.