### PR TITLE
FileIO interface

### DIFF
--- a/src/BSON.jl
+++ b/src/BSON.jl
@@ -34,6 +34,7 @@ include("write.jl")
 include("read.jl")
 include("extensions.jl")
 include("anonymous.jl")
+include("fileio_interface.jl")
 
 using Base.Meta
 

--- a/src/fileio_interface.jl
+++ b/src/fileio_interface.jl
@@ -1,6 +1,7 @@
 #FileIO Interface
 
 fileio_save(f, doc::AbstractDict) = bson(f.filename, doc)
+fileio_save(f, args::Vararg{Pair,N}) where N = bson(f.filename, Dict(args))
 
 #This syntax is already in use to work with |> in FileIO
 #fileio_save(f; kws...) = bson(f.filename, Dict(kws))

--- a/src/fileio_interface.jl
+++ b/src/fileio_interface.jl
@@ -1,0 +1,20 @@
+#FileIO Interface
+
+fileio_save(f, doc::AbstractDict) = bson(f.filename, doc)
+
+#This syntax is already in use to work with |> in FileIO
+#fileio_save(f; kws...) = bson(f.filename, Dict(kws))
+
+function fileio_save(f, args...)
+    @assert length(args) % 2 ==0 "Mismatch between labels and data fields"
+    d = Dict(args[1:2:end] .=> args[2:2:end])
+    bson(f.filename, d)
+end
+
+fileio_load(f) = load(f.filename)
+
+function fileio_load(f, args...)
+    data = load(f.filename)
+    length(args) > 1 && return map( arg -> data[arg], args)
+    return data[args[1]]
+end

--- a/src/fileio_interface.jl
+++ b/src/fileio_interface.jl
@@ -1,16 +1,16 @@
 #FileIO Interface
 
 fileio_save(f, doc::AbstractDict) = bson(f.filename, doc)
-fileio_save(f, args::Vararg{Pair,N}) where N = bson(f.filename, Dict(args))
+fileio_save(f, args::Pair...) = bson(f.filename, Dict(args))
 
 #This syntax is already in use to work with |> in FileIO
 #fileio_save(f; kws...) = bson(f.filename, Dict(kws))
 
-function fileio_save(f, args...)
-    @assert length(args) % 2 ==0 "Mismatch between labels and data fields"
-    d = Dict(args[1:2:end] .=> args[2:2:end])
-    bson(f.filename, d)
-end
+#function fileio_save(f, args...)
+#    @assert length(args) % 2 ==0 "Mismatch between labels and data fields"
+#    d = Dict(args[1:2:end] .=> args[2:2:end])
+#    bson(f.filename, d)
+#end
 
 fileio_load(f) = load(f.filename)
 


### PR DESCRIPTION
Hi,
I implemented the relevant functions for `BSON` to work with `FileIO`.
```
julia> using FileIO

julia> r = rand(10);

julia> str = "Hallo Welt!"
"Hallo Welt!"

julia> num = 42
42

julia> FileIO.save("test.bson", Dict(:r=>r, :str=>str))

julia> FileIO.save("test.bson", :r,r, :str, str, :num, num)

julia> d = FileIO.load("test.bson")
Dict{Symbol,Any} with 3 entries:
  :num => 42
  :str => "Hallo Welt!"
  :r   => [0.19408, 0.929891, 0.890522, 0.854719, 0.0294219, 0.418311, 0.391583, 0.845015, 0.312361, 0.63644]

julia> a,b = FileIO.load("test.bson", :str, :num)
("Hallo Welt!", 42)
```

The syntax `bson("test.bson", a=1, b=2)` sadly cannot be ported as this syntax is already used for working with `|>`.
Instead I implemented it to look like `FileIO.save("test.bson", :a, 1, :b, 2)`.

To add tests for this relatively simple functionality I would need to make `FileIO` a dependency so I haven't done this so far.

The relevant PR to add the format to FileIO as well is here: https://github.com/JuliaIO/FileIO.jl/pull/224

closes #24 