### PR TITLE
Read perf optimisation

### DIFF
--- a/src/BSON.jl
+++ b/src/BSON.jl
@@ -5,8 +5,6 @@ export bson
 
 using Core: SimpleVector, TypeName
 
-import Base.haskey
-
 const BSONDict = Dict{Symbol,Any}
 const BSONArray = Vector{Any}
 const Primitive = Union{Nothing,Bool,Int32,Int64,Float64,String,Vector{UInt8},BSONDict,BSONArray}
@@ -25,12 +23,14 @@ function applychildren!(f::Function, x::BSONDict)::BSONDict
   return x
 end
 
-function applychildren!(f::Function, x::BSONArray)::BSONArray
+function applyvec!(f::Function, x::Vector{T})::Vector{T} where {T}
   for i = 1:length(x)
     x[i] = f(x[i])
   end
   return x
 end
+
+applychildren!(f::Function, x::BSONArray)::BSONArray = applyvec!(f, x)
 
 include("write.jl")
 include("intermediate.jl")

--- a/src/BSON.jl
+++ b/src/BSON.jl
@@ -5,6 +5,8 @@ export bson
 
 using Core: SimpleVector, TypeName
 
+import Base.haskey
+
 const BSONDict = Dict{Symbol,Any}
 const BSONArray = Vector{Any}
 const Primitive = Union{Nothing,Bool,Int32,Int64,Float64,String,Vector{UInt8},BSONDict,BSONArray}
@@ -31,6 +33,7 @@ function applychildren!(f::Function, x::BSONArray)::BSONArray
 end
 
 include("write.jl")
+include("intermediate.jl")
 include("read.jl")
 include("extensions.jl")
 include("anonymous.jl")

--- a/src/BSON.jl
+++ b/src/BSON.jl
@@ -33,21 +33,33 @@ applychildren!(f::Function, x::BSONDict)::BSONDict = applydict!(f, x)
 applychildren!(f::Function, x::BSONArray)::BSONArray = applyvec!(f, x)
 
 "Cache the result of a calculation for a given input"
-memoise(func::Function, input, cache::IdDict{Any, Any}) = if haskey(cache, input)
-  cache[input]
-else
-  cache[input] = func(input)
+macro memoise(input, cache, expr)
+  quote
+    local cache = $(esc(cache))
+    local input = $(esc(input))
+    if haskey(cache, input)
+      cache[input]
+    else
+      cache[input] = $(esc(expr))
+    end
+  end
 end
 
 """Cache the input parameter to calculation as its output
 
 Assumes the object is changed inplace. Allows objects to reference themselves.
 """
-prememoise(func::Function, input, cache::IdDict{Any, Any}) = if haskey(cache, input)
-  cache[input]
-else
-  cache[input] = input
-  func(input)
+macro prememoise(input, cache, expr)
+  quote
+    local cache = $(esc(cache))
+    local input = $(esc(input))
+    if haskey(cache, input)
+      cache[input]
+    else
+      cache[input] = input
+      $(esc(expr))
+    end
+  end
 end
 
 include("write.jl")

--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -54,7 +54,10 @@ end
 
 baremodule __deserialized_types__ end
 
-function newstruct_raw(cache, ::Type{TypeName}, d)
+function newstruct_raw(cache::IdDict{Any, Any}, ::Type{TypeName},
+                       d::Union{BSONDict, TaggedStruct})
+
+  # @debug "Anon newstruct_raw" d[:data][3:6] d[:data][end]
   name = raise_recursive(d[:data][2], cache)
   name = isdefined(__deserialized_types__, name) ? gensym() : name
   tn = ccall(:jl_new_typename_in, Ref{Core.TypeName}, (Any, Any),

--- a/src/anonymous.jl
+++ b/src/anonymous.jl
@@ -64,7 +64,7 @@ function newstruct_raw(cache::IdDict{Any, Any}, ::Type{TypeName},
              name, __deserialized_types__)
   cache[d] = tn
   names, super, parameters, types, has_instance,
-    abstr, mutabl, ninitialized = (raise_recursive(x, cache) for x in d.data[3:end-1])
+    abstr, mutabl, ninitialized = (_raise_recursive(x, cache) for x in d.data[3:end-1])
   tn.names = names
   ndt = ccall(:jl_new_datatype, Any, (Any, Any, Any, Any, Any, Any, Cint, Cint, Cint),
               tn, tn.module, super, parameters, names, types,
@@ -75,7 +75,7 @@ function newstruct_raw(cache::IdDict{Any, Any}, ::Type{TypeName},
     # use setfield! directly to avoid `fieldtype` lowering expecting to see a Singleton object already on ty
     Core.setfield!(ty, :instance, ccall(:jl_new_struct, Any, (Any, Any...), ty))
   end
-  mt = raise_recursive(d.data[end], cache)
+  mt = _raise_recursive(d.data[end], cache)
   if mt != nothing
     mtname, defs, maxa, kwsorter = mt
     tn.mt = ccall(:jl_new_method_table, Any, (Any, Any), name, tn.module)

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -109,7 +109,7 @@ function newstruct_raw(cache::IdDict{Any, Any}, T::Type, d::TaggedStruct)
   #@debug "newstruct_raw" T d
 
   x = cache[d] = initstruct(T)
-  fs = (raise_recursive(x, cache) for x in d[:data])
+  fs = (raise_recursive(x, cache) for x in d.data)
 
   newstruct!(x, fs...)
 end

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -109,7 +109,7 @@ function newstruct_raw(cache::IdDict{Any, Any}, T::Type, d::TaggedStruct)
   #@debug "newstruct_raw" T d
 
   x = cache[d] = initstruct(T)
-  fs = (raise_recursive(x, cache) for x in d.data)
+  fs = (_raise_recursive(x, cache) for x in d.data)
 
   newstruct!(x, fs...)
 end

--- a/src/intermediate.jl
+++ b/src/intermediate.jl
@@ -1,11 +1,18 @@
+"""Type class which represents a tagged dictionary
+
+Tagged dictionaries are used to represent complex Julia types. Using a struct
+instead of an actual Dictionary requires less memory allocation and allows us
+to use multiple dispatch on the resulting tree structure.
+
+It inherits abstract dict just for show."""
 abstract type Tagged <: AbstractDict{Symbol, Any} end
+
+"Type class for types which can occupuy the 'type' field in a struct"
 abstract type TaggedStructType <: Tagged end
 
-Base.haskey(tt::T, k::Symbol) where {T <: Tagged} = k == :tag || k in fieldnames(T)
-Base.isempty(::Tagged) = false
-Base.length(::T) where {T <: Tagged} = length(fieldnames(T))
+# Needed for show
+Base.length(tt::T) where {T <: Tagged} = length(fieldnames(T))
 Base.getindex(tt::Tagged, k::Symbol) = getfield(tt, k)
-Base.setindex!(tt::Tagged, v, k::Symbol) = setfield!(tt, k, v)
 Base.iterate(tt::T) where {T <: Tagged} = let first = fieldnames(T)[1]
   (first => tt[first], 2)
 end

--- a/src/intermediate.jl
+++ b/src/intermediate.jl
@@ -4,6 +4,10 @@ Base.haskey(::Tagged, k::Symbol) = k == :tag
 Base.isempty(::Tagged) = false
 Base.length(::Tagged) = 2
 
+struct TaggedBackref <: Tagged
+  ref::Int64
+end
+
 const TaggedParam = Union{Tagged, TypeVar, BSONDict, Type}
 
 mutable struct TaggedType <: Tagged
@@ -22,7 +26,6 @@ else
 end
 
 function Base.setindex!(tt::TaggedType, v::TaggedType, s::Symbol)
-  @assert s == :params "s = $s ≠ :params"
   tt.params = v
 end
 
@@ -51,7 +54,7 @@ function raise_recursive(v::Vector{TaggedParam}, cache)
 end
 
 mutable struct TaggedStruct <: Tagged
-  ttype::Union{TaggedType, DataType, BSONDict}
+  ttype::Union{TaggedType, TaggedBackref, DataType, BSONDict}
   data::Union{Nothing, BSONArray}
 end
 
@@ -66,7 +69,6 @@ else
 end
 
 function Base.setindex!(ts::TaggedStruct, v::DataType, s::Symbol)
-  @assert s == :type "s = $s ≠ :type"
   ts.ttype = v
 end
 

--- a/src/intermediate.jl
+++ b/src/intermediate.jl
@@ -71,6 +71,20 @@ mutable struct TaggedUnionall <: Tagged
   body::Union{TaggedType, TaggedBackref, TaggedUnionall, TaggedAnonymous}
 end
 
+struct BackRefsWrapper
+  root::Union{BSONDict, TaggedStruct}
+  refs::BSONArray
+end
+
+function Base.show(io::IO, brw::BackRefsWrapper)
+  summary(io, brw)
+  print(io, ".root => ")
+  show(io, MIME("text/plain"), brw.root)
+  summary(io, brw)
+  print(io, ".refs => ")
+  show(io, MIME("text/plain"), brw.refs)
+end
+
 function applychildren!(f::Function, tt::Union{TaggedTuple, TaggedSvec})
   tt.data = f(tt.data)
   tt

--- a/src/intermediate.jl
+++ b/src/intermediate.jl
@@ -1,10 +1,14 @@
 abstract type Tagged <: AbstractDict{Symbol, Any} end
 
 Base.haskey(::Tagged, k::Symbol) = k == :tag
+Base.isempty(::Tagged) = false
+Base.length(::Tagged) = 2
+
+const TaggedParam = Union{Tagged, TypeVar, BSONDict, Type}
 
 mutable struct TaggedType <: Tagged
   name::Vector{String}
-  params::Vector{TaggedType}
+  params::Vector{TaggedParam}
 end
 
 Base.getindex(tt::TaggedType, k::Symbol) = if k == :tag
@@ -17,20 +21,70 @@ else
   error("Can't set $k")
 end
 
+function Base.setindex!(tt::TaggedType, v::TaggedType, s::Symbol)
+  @assert s == :params "s = $s ≠ :params"
+  tt.params = v
+end
+
+Base.iterate(tt::TaggedType) = (:name => tt.name, 1)
+Base.iterate(tt::TaggedType, state) = if state == 1
+  (:params => tt.params, 2)
+else
+  nothing
+end
+
+function applychildren!(f::Function, tt::TaggedType)::TaggedType
+  tt.params = f(tt.params)
+  tt
+end
+applychildren!(f::Function, params::Vector{TaggedParam})::Vector{TaggedParam} =
+  applyvec!(f, params)
+
+raise_recursive(tt::TaggedType, cache)::Type = get(cache, tt) do
+  applychildren!(x -> raise_recursive(x, cache), tt)
+  tags[:datatype](tt)
+end
+
+function raise_recursive(v::Vector{TaggedParam}, cache)
+  cache[v] = v
+  applychildren!(x -> raise_recursive(x, cache), v)
+end
+
 mutable struct TaggedStruct <: Tagged
-  ttype::Union{TaggedType, DataType}
-  data::Vector{Union{Primitive, TaggedStruct}}
+  ttype::Union{TaggedType, DataType, BSONDict}
+  data::Union{Nothing, BSONArray}
 end
 
 Base.getindex(ts::TaggedStruct, k::Symbol) = if k == :tag
   "struct"
 elseif k == :type
   ts.ttype
-elseif k == :data
+elseif k == :data && ts.data ≠ nothing
   ts.data
 else
-  error("Can't set $k")
+  error("Can't get $k")
 end
 
-Base.setindex!(ts::TaggedStruct, ::Symbol, v::DataType) =
+function Base.setindex!(ts::TaggedStruct, v::DataType, s::Symbol)
+  @assert s == :type "s = $s ≠ :type"
   ts.ttype = v
+end
+
+Base.iterate(ts::TaggedStruct) = (:type => ts.ttype, 1)
+Base.iterate(ts::TaggedStruct, state) = if state == 1 && ts.data ≠ nothing
+  (:data => ts.data, 2)
+else
+  nothing
+end
+
+function applychildren!(f::Function, ts::TaggedStruct)::TaggedStruct
+  ts.ttype = f(ts.ttype)
+  if ts.data != nothing
+    ts.data = f(ts.data::BSONArray)
+  end
+  ts
+end
+
+raise_recursive(ts::TaggedStruct, cache) = get(cache, ts) do
+  raise[:struct](ts, cache)
+end

--- a/src/intermediate.jl
+++ b/src/intermediate.jl
@@ -1,0 +1,36 @@
+abstract type Tagged <: AbstractDict{Symbol, Any} end
+
+Base.haskey(::Tagged, k::Symbol) = k == :tag
+
+mutable struct TaggedType <: Tagged
+  name::Vector{String}
+  params::Vector{TaggedType}
+end
+
+Base.getindex(tt::TaggedType, k::Symbol) = if k == :tag
+  "datatype"
+elseif k == :name
+  tt.name
+elseif k == :params
+  tt.params
+else
+  error("Can't set $k")
+end
+
+mutable struct TaggedStruct <: Tagged
+  ttype::Union{TaggedType, DataType}
+  data::Vector{Union{Primitive, TaggedStruct}}
+end
+
+Base.getindex(ts::TaggedStruct, k::Symbol) = if k == :tag
+  "struct"
+elseif k == :type
+  ts.ttype
+elseif k == :data
+  ts.data
+else
+  error("Can't set $k")
+end
+
+Base.setindex!(ts::TaggedStruct, ::Symbol, v::DataType) =
+  ts.ttype = v

--- a/src/intermediate.jl
+++ b/src/intermediate.jl
@@ -8,6 +8,8 @@ struct TaggedBackref <: Tagged
   ref::Int64
 end
 
+Base.show(io::IO, br::TaggedBackref) = print(io, "Ref(", br.ref, ")")
+
 const TaggedParam = Union{Tagged, TypeVar, BSONDict, Type}
 
 mutable struct TaggedType <: Tagged

--- a/src/read.jl
+++ b/src/read.jl
@@ -91,10 +91,10 @@ function parse_doc(io::IO)::Union{BSONDict, TaggedStruct, TaggedType}
     end
   end
 
-  if ttag[2] == "struct"
+  if !other[1] && ttag[2] == "struct"
     @assert ttype[1]
     return TaggedStruct(ttype[2], tdata[2])
-  elseif ttag[2] == "datatype"
+  elseif !other[1] && ttag[2] == "datatype"
     return TaggedType(tname[2], tparams[2])
   end
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -156,7 +156,7 @@ const tags = Dict{Symbol,Function}()
 
 const raise = Dict{Symbol,Function}()
 
-function _raise_recursive(d::AbstractDict, cache)
+function _raise_recursive(d::BSONDict, cache::IdDict{Any, Any})
   if haskey(d, :tag) && haskey(tags, Symbol(d[:tag]))
     cache[d] = tags[Symbol(d[:tag])](applychildren!(x -> raise_recursive(x, cache), d))
   else
@@ -165,20 +165,20 @@ function _raise_recursive(d::AbstractDict, cache)
   end
 end
 
-function raise_recursive(d::AbstractDict, cache)
+function raise_recursive(d::BSONDict, cache::IdDict{Any, Any})
   haskey(cache, d) && return cache[d]
   haskey(d, :tag) && haskey(raise, Symbol(d[:tag])) && return raise[Symbol(d[:tag])](d, cache)
   _raise_recursive(d::AbstractDict, cache)
 end
 
-function raise_recursive(v::AbstractVector, cache)
+function raise_recursive(v::BSONArray, cache::IdDict{Any, Any})
   cache[v] = v
   applychildren!(x -> raise_recursive(x, cache), v)
 end
 
-raise_recursive(x, cache) = x
+raise_recursive(x, ::IdDict{Any, Any}) = x
 
-raise_recursive(x) = raise_recursive(x, IdDict())
+raise_recursive(x) = raise_recursive(x, IdDict{Any, Any}())
 
 parse(io::IO) = backrefs!(parse_doc(io))
 parse(path::String) = open(parse, path)

--- a/src/read.jl
+++ b/src/read.jl
@@ -286,17 +286,6 @@ function backrefs!(dict::BackRefsWrapper)
   backrefs!(dict.root, dict.refs)
 end
 
-raise_recursive(d::BSONDict, cache::IdDict{Any, Any}) = @prememoise d cache begin
-  haskey(d, :tag) && error("Unknown tag: $(d[:tag])")
-  applychildren!(x -> raise_recursive(x, cache), d)
-end
-
-raise_recursive(v::BSONArray, cache::IdDict{Any, Any}) = @prememoise v cache begin
-  applyvec!(x -> raise_recursive(x, cache), v)
-end
-
-raise_recursive(x::Union{Primitive, Type{Union{}}, Symbol}, ::IdDict{Any, Any}) = x
-
 parse(io::IOT) where {IOT <: IO} = backrefs!(parse_doc(io))
 parse(path::String) = open(parse, path)
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -284,17 +284,13 @@ function backrefs!(dict)
   return dict
 end
 
-const tags = Dict{Symbol,Function}()
-
-const raise = Dict{Symbol,Function}()
-
-raise_recursive(d::BSONDict, cache::IdDict{Any, Any}) = prememoise(d, cache) do d
+raise_recursive(d::BSONDict, cache::IdDict{Any, Any}) = @prememoise d cache begin
   haskey(d, :tag) && error("Unknown tag: $(d[:tag])")
   applychildren!(x -> raise_recursive(x, cache), d)
 end
 
-raise_recursive(v::BSONArray, cache::IdDict{Any, Any}) = prememoise(v, cache) do u
-  applyvec!(x -> raise_recursive(x, cache), u)
+raise_recursive(v::BSONArray, cache::IdDict{Any, Any}) = @prememoise v cache begin
+  applyvec!(x -> raise_recursive(x, cache), v)
 end
 
 raise_recursive(x::Union{Primitive, Type{Union{}}, Symbol}, ::IdDict{Any, Any}) = x

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -103,8 +103,8 @@ if get(ENV, "JULIA_PROFILE", nothing) != nothing
   
   GC.gc()
   @info "Profile Raise BSON to Julia types"
-  rfoos = @profile BSON.raise_recursive(dict)
-  Profile.print(;noisefloor=2, mincount=minc)
+  rfoos = @profile BSON.raise_recursive(dict, IdDict{Any, Any}())
+  Profile.print(;noisefloor=2, mincount=minc, C=true)
   Profile.clear()
 end
 

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -30,65 +30,78 @@ struct Foo
   projects::Vector{Bar}
 end
 
-Foo() = Foo(rstr(5), rstr(7), rstr(17), rstr(11), rstr(13), [Bar() for _ in 1:2000])
+Foo() = [Foo(rstr(5), rstr(7), rstr(17), rstr(11), rstr(13),
+             [Bar() for _ in 1:2000]) for _ in 1:5]
+
+struct Result
+  elapsed::Float64
+  allocated::Int64
+end
 
 const history_file = "./benchmark-history.bson"
 history = if isfile(history_file)
-    BSON.load(history_file)
+    BSON.load(history_file)::Dict{String, Result}
 else
-    Dict()
+    Dict{String, Result}()
 end
 
 macro bench(msg, ex)
-    sex = "$ex"
-    quote
-        GC.gc()
-        @info $msg
-        local val, t1, bytes, gctime, memallocs = @timed $(esc(ex))
-        kb = bytes / 1024
-        if $sex in keys(history)
-            @info $sex elapsed=t1 speedup=history[$sex]/t1 allocatedKb=bytes gctime
-        else
-            @info $sex elapsed=t1 allocatedKb=bytes gctime
-        end
-        history[$sex] = t1
-        val
+  sex = "$ex"
+  quote
+    GC.gc()
+    @info $msg
+    local val, t1, bytes, gctime, memallocs = @timed $(esc(ex))
+    local mb = ceil(bytes / (1024 * 1024))
+    if $sex in keys(history)
+      local t0 = history[$sex].elapsed
+      @info $sex elapsed=t1 speedup=t0/t1 allocatedMb=mb gctime
+    else
+      @info $sex elapsed=t1 allocatedMb=mb gctime
     end
+    history[$sex] = Result(t1, bytes)
+    val
+  end
 end
 
 foos = Dict(:Foo => Foo(), :Foo2 => Foo(), :Foo3 => Foo())
+
+@bench "Roundtrip from cold start (ignore)" BSON.roundtrip(foos)
+
 io = IOBuffer()
 
 @bench "Bench Save BSON" bson(io, foos)
 seek(io, 0)
 
 dict = @bench "Bench Parse BSON" BSON.parse(io)
-@bench "Bench Raise BSON to Julia types" BSON.raise_recursive(dict)
+rfoos = @bench "Bench Raise BSON to Julia types" BSON.raise_recursive(dict)
 
 bson(history_file, history)
 
-GC.gc()
-@info "Profile Save BSON"
-@profile bson(io, foos)
-Profile.print(;noisefloor=2)
-Profile.clear()
-seek(io, 0)
+if get(ENV, "JULIA_PROFILE", nothing) != nothing
+  seek(io, 0)
+  GC.gc()
+  @info "Profile Save BSON"
+  @profile bson(io, foos)
+  Profile.print(;noisefloor=2)
+  Profile.clear()
+  seek(io, 0)
 
-GC.gc()
-@info "Profile Parse BSON"
-dict = @profile BSON.parse(io)
-Profile.print(;noisefloor=2, C=true)
-Profile.clear()
+  GC.gc()
+  @info "Profile Parse BSON"
+  dict = @profile BSON.parse(io)
+  Profile.print(;noisefloor=2, C=true)
+  Profile.clear()
 
-GC.gc()
-@info "Profile Raise BSON to Julia types"
-rfoos = @profile BSON.raise_recursive(dict)
-Profile.print(;noisefloor=2)
-Profile.clear()
+  GC.gc()
+  @info "Profile Raise BSON to Julia types"
+  rfoos = @profile BSON.raise_recursive(dict)
+  Profile.print(;noisefloor=2)
+  Profile.clear()
+end
 
 # Sanity check the results
-rfoos[:Foo]::Foo
-rfoos[:Foo].projects[1]::Bar
-rfoos[:Foo].projects[1].bazes[1]::Baz
+rfoos[:Foo][1]::Foo
+rfoos[:Foo][1].projects[1]::Bar
+rfoos[:Foo][1].projects[1].bazes[1]::Baz
 
 end

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -75,7 +75,7 @@ seek(io, 0)
 doc = @bench "Bench Parse BSON Document" BSON.parse_doc(io)
 dref_doc = deepcopy(doc)
 dref_doc = @bench "Bench deref" BSON.backrefs!(dref_doc)
-rfoos = @bench "Bench Raise BSON to Julia types" BSON.raise_recursive(dref_doc)
+rfoos = @bench "Bench Raise BSON to Julia types" BSON.raise_recursive(dref_doc, IdDict{Any, Any}())
 
 bson(history_file, history)
 

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -56,7 +56,7 @@ macro bench(msg, ex)
     end
 end
 
-foos = Dict(:Foo => Foo())
+foos = Dict(:Foo => Foo(), :Foo2 => Foo(), :Foo3 => Foo())
 io = IOBuffer()
 
 @bench "Bench Save BSON" bson(io, foos)
@@ -67,17 +67,20 @@ dict = @bench "Bench Parse BSON" BSON.parse(io)
 
 bson(history_file, history)
 
+GC.gc()
 @info "Profile Save BSON"
 @profile bson(io, foos)
 Profile.print(;noisefloor=2)
 Profile.clear()
 seek(io, 0)
 
+GC.gc()
 @info "Profile Parse BSON"
 dict = @profile BSON.parse(io)
 Profile.print(;noisefloor=2, C=true)
 Profile.clear()
 
+GC.gc()
 @info "Profile Raise BSON to Julia types"
 rfoos = @profile BSON.raise_recursive(dict)
 Profile.print(;noisefloor=2)

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -92,6 +92,8 @@ function do_bench()
 end
 
 function do_profile()
+  io = IOBuffer()
+  foos = Dict(:Foo => Foo(), :Foo2 => Foo(), :Foo3 => Foo())
   minc = parse(Int64, get(ENV, "JULIA_PROFILE_MIN", "0"))
   seek(io, 0)
   GC.gc()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using Test
 
 roundtrip_equal(x) = BSON.roundtrip(x) == x
 
+abstract type Bar end
+
 mutable struct Foo
   x
 end
@@ -12,6 +14,8 @@ struct T{A}
 end
 
 struct S end
+
+struct Baz <: Bar end
 
 @testset "BSON" begin
 
@@ -42,6 +46,7 @@ end
   @test roundtrip_equal(Set([1,2,3]))
   @test roundtrip_equal(Dict("a"=>1))
   @test roundtrip_equal(T(()))
+  @test roundtrip_equal(T{Bar}(Baz()))
 end
 
 @testset "Circular References" begin


### PR DESCRIPTION
It seems that a large amount of time and memory is taken allocating intermediate Dictionary objects which are then raised to native Julia types. It should be faster to skip creating the intermediate Dictionarys and create the end types directly.

This PR doesn't create the end types directly yet, however it replaces the intermediate dictionaries with some fixed size intermediate structures. I haven't replaced all the dictionaries yet and I am doing some weird stuff with subtyping AbstractDictionary so that I can make the changes piecemeal, but this still results in an  80-100% speedup and 50% less memory usage on the benchmark (which is rather backref heavy). This is not close to the kind of speed up I wanted though.

Since making the changes it is no longer clear to me what is taking up the most time (other than string allocation). However I think removing as many dynamic calls as possible will help as well as cutting out the intermediate stage altogether. Of course we still want to be able to see how the data is represented before it is raised to Julia types for debugging. So I will try to keep that.