### PR TITLE
improve performance

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -59,8 +59,13 @@ tags[:unionall] = d -> UnionAll(d[:var], d[:body])
 lower(x::Vector{Any}) = copy(x)
 lower(x::Vector{UInt8}) = x
 
-reinterpret_(::Type{T}, x) where T =
-  T[reinterpret(T, x)...]
+function reinterpret_(::Type{T}, x) where T
+  len = Int(length(x) * (sizeof(eltype(x)) / sizeof(T)))
+  GC.@preserve x begin
+    return unsafe_wrap(Array, Ptr{T}(pointer(x)), len)
+  end
+end
+
 
 function lower(x::Array)
   ndims(x) == 1 && !isbitstype(eltype(x)) && return Any[x...]


### PR DESCRIPTION
After benchmarking BSON to figure out if it's a good replacement for JSON, I noticed that its by far the slowest. This PR fixes the performance partly:
```julia
@time BSON.bson("test.bson_master", Dict(:a=>x)) # 3.2s
@time open(io-> JSON.print(io, x), "test.json", "w") # 1.6s
@time open(io-> JSON2.write(io, x), "test.json2", "w") # 1.1s
@time BSON.bson("test.bson_this_pr", Dict(:a=>x)) # 0.26s
@time open(io-> CBOR.encode(io, x), "test.cbor", "w") # 0.16
```
It's still slower than CBOR, which also isn't doing the fastest it could - so I guess there are still some other low hanging fruits in here ;)