### PR TITLE
improve performance for reinterpret_

### DIFF
--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -65,7 +65,7 @@ lower(x::Vector{Any}) = copy(x)
 lower(x::Vector{UInt8}) = x
 
 reinterpret_(::Type{T}, x) where T =
-  T[reinterpret(T, x)...]
+    T[_x for _x in reinterpret(T, x)]
 
 function lower(x::Array)
   ndims(x) == 1 && !isbitstype(eltype(x)) && return Any[x...]


### PR DESCRIPTION
```
julia> @time Metalhead.weights("vgg19.bson")
  2.330473 seconds (1.91 M allocations: 1.164 GiB, 7.87% gc time)
```

Fixes #45 