### PR TITLE
Saving array length for undef array issues

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -35,12 +35,17 @@ function parse_array(io::IO)::BSONArray
 
   while (tag = read(io, BSONType)) ≠ eof
     # Note that arrays are dicts with the index as the key
-    while read(io, UInt8) != 0x00
-      nothing
-    end
-    push!(ps, parse_tag(io::IO, tag))
+    # The first index in dict is "length" => length(x)
+      index_or_length = parse_cstr(io)
+      val = parse_tag(io::IO, tag)
+      if index_or_length == "length"
+        resize!(ps, Int(val))
+      else
+        i = Base.parse(Int, index_or_length) + 1
+        resize!(ps, i)
+        ps[i] = val
+      end
   end
-
   ps
 end
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -35,7 +35,7 @@ end
 
 bson_primitive(io::IO, doc::BSONDict) = bson_doc(io, doc)
 bson_primitive(io::IO, x::BSONArray) =
-  bson_doc(io, [Base.string(i-1) => v for (i, v) in enumerate(x)])
+  bson_doc(io, vcat(["length" => length(x)],[Base.string(i-1) => x[i] for i = 1:length(x) if isassigned(x, i)]))
 
 # Lowering
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,29 @@ using BSON
 using Test
 
 roundtrip_equal(x) = BSON.roundtrip(x) == x
+function roundtrip_equal(x::AbstractArray)
+  result = BSON.roundtrip(x)
+  all(eachindex(result, x)) do I
+    if !isassigned(x, I)
+      !isassigned(result, I)
+    else
+      x[I] == result[I]
+    end
+  end
+end
+
+function roundtrip_equal(x::Dict{Any,Array{Any,2}})
+  result = BSON.roundtrip(x)
+  keys(result) == keys(x)
+  all(keys(x)) do key
+    if isassigned(x[key])
+      x[key] == result[key]
+    else
+      isassigned(x[key]) == isassigned(result[key])
+    end
+  end
+end
+
 
 mutable struct Foo
   x
@@ -33,6 +56,7 @@ end
   @test roundtrip_equal(Array)
   @test roundtrip_equal([1,2,3])
   @test roundtrip_equal(rand(2,3))
+  @test roundtrip_equal(Array{Real}(undef, 2,3))
   @test roundtrip_equal(Array{Real}(rand(2,3)))
   @test roundtrip_equal(1+2im)
   @test roundtrip_equal(Nothing[])
@@ -41,6 +65,7 @@ end
   @test roundtrip_equal(fill(S(), (1,3)))
   @test roundtrip_equal(Set([1,2,3]))
   @test roundtrip_equal(Dict("a"=>1))
+  @test roundtrip_equal(Dict("a"=>Array{Real}(undef, 2,3)))
   @test roundtrip_equal(T(()))
 end
 


### PR DESCRIPTION
Changed saving format to save array length as item in the sparse dict when writing arrays. Uses the length key while reading the array to allocate the necessary length of the array. Backwards compatible with existing BSON dumps.